### PR TITLE
feat: Dashboard debt list and summary stats (#7, #8)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,30 @@
 import { useState } from 'react'
 import Dashboard from './components/Dashboard'
 import DebtForm from './components/DebtForm'
+import type { Debt } from './types/debt'
 
 type Tab = 'dashboard' | 'add-debt'
 
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>('dashboard')
+  const [editingDebt, setEditingDebt] = useState<Debt | null>(null)
+
+  const handleEditDebt = (debt: Debt) => {
+    setEditingDebt(debt)
+    setActiveTab('add-debt')
+  }
+
+  const handleFormSave = () => {
+    setEditingDebt(null)
+    setActiveTab('dashboard')
+  }
+
+  const handleTabChange = (tab: Tab) => {
+    if (tab === 'dashboard') setEditingDebt(null)
+    setActiveTab(tab)
+  }
+
+  const addDebtLabel = editingDebt ? 'Edit Debt' : 'Add Debt'
 
   return (
     <div className="min-h-screen bg-white">
@@ -21,7 +40,7 @@ function App() {
             {/* Nav tabs */}
             <div className="flex gap-1">
               <button
-                onClick={() => setActiveTab('dashboard')}
+                onClick={() => handleTabChange('dashboard')}
                 className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
                   activeTab === 'dashboard'
                     ? 'bg-gray-700 text-white'
@@ -31,14 +50,14 @@ function App() {
                 Dashboard
               </button>
               <button
-                onClick={() => setActiveTab('add-debt')}
+                onClick={() => handleTabChange('add-debt')}
                 className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
                   activeTab === 'add-debt'
                     ? 'bg-gray-700 text-white'
                     : 'text-gray-300 hover:bg-gray-800 hover:text-white'
                 }`}
               >
-                Add Debt
+                {addDebtLabel}
               </button>
             </div>
           </div>
@@ -47,7 +66,17 @@ function App() {
 
       {/* Main content */}
       <main className="mx-auto max-w-5xl px-4 py-6">
-        {activeTab === 'dashboard' ? <Dashboard /> : <DebtForm />}
+        {activeTab === 'dashboard' ? (
+          <Dashboard
+            onAddDebt={() => handleTabChange('add-debt')}
+            onEditDebt={handleEditDebt}
+          />
+        ) : (
+          <DebtForm
+            initialData={editingDebt ?? undefined}
+            onSave={handleFormSave}
+          />
+        )}
       </main>
     </div>
   )

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,101 @@
-export default function Dashboard() {
+import { useDebtStore } from '../store/useDebtStore'
+import { calculatePayoffPlan, formatCurrency, formatDuration } from '../utils/calculations'
+import DebtCard from './DebtCard'
+import type { Debt } from '../types/debt'
+
+interface DashboardProps {
+  onAddDebt: () => void
+  onEditDebt: (debt: Debt) => void
+}
+
+function formatPayoffDate(yyyyMM: string): string {
+  if (!yyyyMM) return '—'
+  const [year, month] = yyyyMM.split('-').map(Number)
+  return new Date(year, month - 1).toLocaleDateString('en-GB', {
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+export default function Dashboard({ onAddDebt, onEditDebt }: DashboardProps) {
+  const debts = useDebtStore((s) => s.debts)
+
+  const sorted = [...debts].sort((a, b) => b.balance - a.balance)
+
+  if (debts.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <p className="text-gray-400 text-lg mb-2">No debts tracked yet</p>
+        <p className="text-gray-400 text-sm mb-6">Add your first debt to start planning your payoff.</p>
+        <button
+          onClick={onAddDebt}
+          className="px-5 py-2 bg-indigo-600 text-white rounded-md font-medium hover:bg-indigo-700 transition-colors"
+        >
+          Add your first debt
+        </button>
+      </div>
+    )
+  }
+
+  const plans = debts.map((d) => calculatePayoffPlan(d))
+  const totalDebt = debts.reduce((sum, d) => sum + d.balance, 0)
+  const totalMonthly = debts.reduce((sum, d) => sum + d.monthlyPayment, 0)
+  const totalMinimum = debts.reduce((sum, d) => sum + d.minimumPayment, 0)
+  const totalInterest = plans.reduce((sum, p) => sum + p.totalInterestPaid, 0)
+  const latestPayoff = plans.reduce(
+    (latest, p) => (p.payoffDate > latest ? p.payoffDate : latest),
+    ''
+  )
+  const totalMonths = plans.reduce((max, p) => Math.max(max, p.monthsToPayoff), 0)
+
   return (
-    <div className="p-6 text-gray-500">Dashboard (coming soon)</div>
+    <div className="space-y-6">
+      {/* Summary stats bar */}
+      <div className="bg-gray-50 border border-gray-200 rounded-lg p-5">
+        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-4">Overview</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+          <SummaryStat label="Total debt" value={formatCurrency(totalDebt)} />
+          <SummaryStat label="Monthly payment" value={formatCurrency(totalMonthly)} />
+          <SummaryStat label="Minimum payment" value={formatCurrency(totalMinimum)} />
+          <SummaryStat
+            label="Extra per month"
+            value={formatCurrency(totalMonthly - totalMinimum)}
+            highlight={totalMonthly > totalMinimum}
+          />
+          <SummaryStat label="Debt-free date" value={formatPayoffDate(latestPayoff)} />
+          <SummaryStat label="Time remaining" value={formatDuration(totalMonths)} />
+        </div>
+        <div className="mt-3 pt-3 border-t border-gray-200">
+          <span className="text-xs text-gray-500">Total interest to pay: </span>
+          <span className="text-sm font-semibold text-red-600">{formatCurrency(totalInterest)}</span>
+        </div>
+      </div>
+
+      {/* Debt list */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {sorted.map((debt) => (
+          <DebtCard key={debt.id} debt={debt} onEdit={onEditDebt} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SummaryStat({
+  label,
+  value,
+  highlight,
+}: {
+  label: string
+  value: string
+  highlight?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-xs text-gray-500">{label}</dt>
+      <dd className={`text-sm font-semibold mt-0.5 ${highlight ? 'text-green-600' : 'text-gray-900'}`}>
+        {value}
+      </dd>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Dashboard renders all DebtCards sorted by balance descending (#7)
- Empty state with a CTA button to add the first debt
- Summary stats bar above the list: total debt, monthly payment, minimum payment, extra per month (highlighted green), debt-free date, time remaining, total interest paid (#8)
- Edit flow wired up end-to-end: clicking Edit on a card switches the nav to "Edit Debt" tab with the form pre-filled; saving returns to Dashboard

Closes #7, closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)