### PR TITLE
feat: strategy comparison, extra payment simulator, dark mode (#11, #12, #13)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
   const addDebtLabel = editingDebt ? 'Edit Debt' : 'Add Debt'
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-white dark:bg-gray-900">
       {/* Navigation bar */}
       <nav className="bg-gray-900 text-white">
         <div className="mx-auto max-w-5xl px-4">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,6 +2,8 @@ import { useDebtStore } from '../store/useDebtStore'
 import { calculatePayoffPlan, formatCurrency, formatDuration } from '../utils/calculations'
 import DebtCard from './DebtCard'
 import PayoffChart from './PayoffChart'
+import StrategyComparison from './StrategyComparison'
+import ExtraPaymentSimulator from './ExtraPaymentSimulator'
 import type { Debt } from '../types/debt'
 
 interface DashboardProps {
@@ -20,14 +22,15 @@ function formatPayoffDate(yyyyMM: string): string {
 
 export default function Dashboard({ onAddDebt, onEditDebt }: DashboardProps) {
   const debts = useDebtStore((s) => s.debts)
-
   const sorted = [...debts].sort((a, b) => b.balance - a.balance)
 
   if (debts.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-24 text-center">
-        <p className="text-gray-400 text-lg mb-2">No debts tracked yet</p>
-        <p className="text-gray-400 text-sm mb-6">Add your first debt to start planning your payoff.</p>
+        <p className="text-gray-400 dark:text-gray-500 text-lg mb-2">No debts tracked yet</p>
+        <p className="text-gray-400 dark:text-gray-500 text-sm mb-6">
+          Add your first debt to start planning your payoff.
+        </p>
         <button
           onClick={onAddDebt}
           className="px-5 py-2 bg-indigo-600 text-white rounded-md font-medium hover:bg-indigo-700 transition-colors"
@@ -52,8 +55,10 @@ export default function Dashboard({ onAddDebt, onEditDebt }: DashboardProps) {
   return (
     <div className="space-y-6">
       {/* Summary stats bar */}
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-5">
-        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-4">Overview</h2>
+      <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-5">
+        <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+          Overview
+        </h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
           <SummaryStat label="Total debt" value={formatCurrency(totalDebt)} />
           <SummaryStat label="Monthly payment" value={formatCurrency(totalMonthly)} />
@@ -66,14 +71,22 @@ export default function Dashboard({ onAddDebt, onEditDebt }: DashboardProps) {
           <SummaryStat label="Debt-free date" value={formatPayoffDate(latestPayoff)} />
           <SummaryStat label="Time remaining" value={formatDuration(totalMonths)} />
         </div>
-        <div className="mt-3 pt-3 border-t border-gray-200">
-          <span className="text-xs text-gray-500">Total interest to pay: </span>
-          <span className="text-sm font-semibold text-red-600">{formatCurrency(totalInterest)}</span>
+        <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+          <span className="text-xs text-gray-500 dark:text-gray-400">Total interest to pay: </span>
+          <span className="text-sm font-semibold text-red-600 dark:text-red-400">
+            {formatCurrency(totalInterest)}
+          </span>
         </div>
       </div>
 
       {/* Payoff chart */}
       <PayoffChart debts={sorted} />
+
+      {/* Strategy comparison */}
+      <StrategyComparison debts={sorted} />
+
+      {/* Extra payment simulator */}
+      <ExtraPaymentSimulator debts={sorted} />
 
       {/* Debt list */}
       <div className="grid gap-4 sm:grid-cols-2">
@@ -96,8 +109,8 @@ function SummaryStat({
 }) {
   return (
     <div>
-      <dt className="text-xs text-gray-500">{label}</dt>
-      <dd className={`text-sm font-semibold mt-0.5 ${highlight ? 'text-green-600' : 'text-gray-900'}`}>
+      <dt className="text-xs text-gray-500 dark:text-gray-400">{label}</dt>
+      <dd className={`text-sm font-semibold mt-0.5 ${highlight ? 'text-green-600 dark:text-green-400' : 'text-gray-900 dark:text-gray-100'}`}>
         {value}
       </dd>
     </div>

--- a/src/components/DebtCard.tsx
+++ b/src/components/DebtCard.tsx
@@ -3,38 +3,6 @@ import { useDebtStore } from '../store/useDebtStore'
 import { calculatePayoffPlan, formatCurrency, formatDuration } from '../utils/calculations'
 import type { Debt } from '../types/debt'
 
-function AmortizationTable({ debt }: { debt: Debt }) {
-  const { schedule } = calculatePayoffPlan(debt)
-  return (
-    <div className="mt-4 border-t border-gray-100 pt-4 overflow-x-auto">
-      <table className="w-full text-xs text-gray-700">
-        <thead>
-          <tr className="text-left text-gray-400 border-b border-gray-100">
-            <th className="pb-2 font-medium">Month</th>
-            <th className="pb-2 font-medium">Date</th>
-            <th className="pb-2 font-medium text-right">Payment</th>
-            <th className="pb-2 font-medium text-right">Principal</th>
-            <th className="pb-2 font-medium text-right">Interest</th>
-            <th className="pb-2 font-medium text-right">Balance</th>
-          </tr>
-        </thead>
-        <tbody>
-          {schedule.map((row) => (
-            <tr key={row.month} className="border-b border-gray-50">
-              <td className="py-1">{row.month}</td>
-              <td className="py-1">{row.date}</td>
-              <td className="py-1 text-right">{formatCurrency(row.payment)}</td>
-              <td className="py-1 text-right text-green-700">{formatCurrency(row.principal)}</td>
-              <td className="py-1 text-right text-red-500">{formatCurrency(row.interest)}</td>
-              <td className="py-1 text-right font-medium">{formatCurrency(row.remainingBalance)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  )
-}
-
 interface DebtCardProps {
   debt: Debt
   onEdit?: (debt: Debt) => void
@@ -49,6 +17,38 @@ function formatPayoffDate(yyyyMM: string): string {
   })
 }
 
+function AmortizationTable({ debt }: { debt: Debt }) {
+  const { schedule } = calculatePayoffPlan(debt)
+  return (
+    <div className="mt-4 border-t border-gray-100 dark:border-gray-700 pt-4 overflow-x-auto">
+      <table className="w-full text-xs text-gray-700 dark:text-gray-300">
+        <thead>
+          <tr className="text-left text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-gray-700">
+            <th className="pb-2 font-medium">Month</th>
+            <th className="pb-2 font-medium">Date</th>
+            <th className="pb-2 font-medium text-right">Payment</th>
+            <th className="pb-2 font-medium text-right">Principal</th>
+            <th className="pb-2 font-medium text-right">Interest</th>
+            <th className="pb-2 font-medium text-right">Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {schedule.map((row) => (
+            <tr key={row.month} className="border-b border-gray-50 dark:border-gray-700/50">
+              <td className="py-1">{row.month}</td>
+              <td className="py-1">{row.date}</td>
+              <td className="py-1 text-right">{formatCurrency(row.payment)}</td>
+              <td className="py-1 text-right text-green-700 dark:text-green-400">{formatCurrency(row.principal)}</td>
+              <td className="py-1 text-right text-red-500 dark:text-red-400">{formatCurrency(row.interest)}</td>
+              <td className="py-1 text-right font-medium">{formatCurrency(row.remainingBalance)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export default function DebtCard({ debt, onEdit }: DebtCardProps) {
   const removeDebt = useDebtStore((s) => s.removeDebt)
   const [confirming, setConfirming] = useState(false)
@@ -57,10 +57,10 @@ export default function DebtCard({ debt, onEdit }: DebtCardProps) {
   const plan = calculatePayoffPlan(debt)
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-5">
       {confirming ? (
         <div className="flex flex-col gap-3">
-          <p className="text-sm text-gray-700">
+          <p className="text-sm text-gray-700 dark:text-gray-300">
             Are you sure you want to delete <span className="font-semibold">{debt.name}</span>?
           </p>
           <div className="flex gap-2">
@@ -72,7 +72,7 @@ export default function DebtCard({ debt, onEdit }: DebtCardProps) {
             </button>
             <button
               onClick={() => setConfirming(false)}
-              className="px-4 py-1.5 border border-gray-300 text-gray-700 text-sm rounded-md hover:bg-gray-50 transition-colors"
+              className="px-4 py-1.5 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             >
               Cancel
             </button>
@@ -81,17 +81,17 @@ export default function DebtCard({ debt, onEdit }: DebtCardProps) {
       ) : (
         <>
           <div className="flex items-start justify-between mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">{debt.name}</h3>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{debt.name}</h3>
             <div className="flex gap-2">
               <button
                 onClick={() => onEdit?.(debt)}
-                className="px-3 py-1 text-sm border border-gray-300 text-gray-600 rounded-md hover:bg-gray-50 transition-colors"
+                className="px-3 py-1 text-sm border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               >
                 Edit
               </button>
               <button
                 onClick={() => setConfirming(true)}
-                className="px-3 py-1 text-sm border border-red-300 text-red-600 rounded-md hover:bg-red-50 transition-colors"
+                className="px-3 py-1 text-sm border border-red-300 dark:border-red-800 text-red-600 dark:text-red-400 rounded-md hover:bg-red-50 dark:hover:bg-red-950/40 transition-colors"
               >
                 Delete
               </button>
@@ -117,7 +117,7 @@ export default function DebtCard({ debt, onEdit }: DebtCardProps) {
 
           <button
             onClick={() => setShowSchedule((v) => !v)}
-            className="mt-4 text-xs text-indigo-600 hover:text-indigo-800 transition-colors"
+            className="mt-4 text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 transition-colors"
           >
             {showSchedule ? '▲ Hide schedule' : '▼ Show amortization schedule'}
           </button>
@@ -140,10 +140,10 @@ function Stat({
 }) {
   return (
     <div>
-      <dt className="text-gray-500">{label}</dt>
-      <dd className="font-medium text-gray-900">
+      <dt className="text-gray-500 dark:text-gray-400">{label}</dt>
+      <dd className="font-medium text-gray-900 dark:text-gray-100">
         {value}
-        {sub && <span className="block text-xs text-gray-400">{sub}</span>}
+        {sub && <span className="block text-xs text-gray-400 dark:text-gray-500">{sub}</span>}
       </dd>
     </div>
   )

--- a/src/components/DebtForm.tsx
+++ b/src/components/DebtForm.tsx
@@ -73,7 +73,7 @@ export default function DebtForm({ initialData, onSave }: DebtFormProps) {
 
   return (
     <div className="max-w-lg mx-auto p-6">
-      <h2 className="text-xl font-semibold text-gray-900 mb-6">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-6">
         {isEditing ? 'Edit Debt' : 'Add New Debt'}
       </h2>
 
@@ -184,17 +184,18 @@ function Field({
 }) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</label>
       {children}
-      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+      {error && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</p>}
     </div>
   )
 }
 
 function input(error?: string) {
   return [
-    'w-full rounded-md border px-3 py-2 text-sm text-gray-900',
+    'w-full rounded-md border px-3 py-2 text-sm',
+    'text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700',
     'focus:outline-none focus:ring-2 focus:ring-indigo-500',
-    error ? 'border-red-400' : 'border-gray-300',
+    error ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600',
   ].join(' ')
 }

--- a/src/components/ExtraPaymentSimulator.tsx
+++ b/src/components/ExtraPaymentSimulator.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { calculateExtraPaymentImpact, formatCurrency, formatDuration } from '../utils/calculations'
+import type { Debt } from '../types/debt'
+
+interface ExtraPaymentSimulatorProps {
+  debts: Debt[]
+}
+
+function formatPayoffDate(yyyyMM: string): string {
+  if (!yyyyMM) return '—'
+  const [year, month] = yyyyMM.split('-').map(Number)
+  return new Date(year, month - 1).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+}
+
+export default function ExtraPaymentSimulator({ debts }: ExtraPaymentSimulatorProps) {
+  const [selectedId, setSelectedId] = useState<string>(debts[0]?.id ?? '')
+  const [amount, setAmount] = useState<number>(0)
+
+  if (debts.length === 0) return null
+
+  const selectedDebt = debts.find((d) => d.id === selectedId) ?? debts[0]
+  const impact = amount > 0 ? calculateExtraPaymentImpact(selectedDebt, amount) : null
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-5">
+      <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+        One-time payment simulator
+      </h2>
+      <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
+        See how a lump-sum payment would affect your payoff timeline. This is a read-only simulation — it does not change your saved data.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+            Apply to
+          </label>
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            {debts.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.name} ({formatCurrency(d.balance)})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+            Extra payment (NOK)
+          </label>
+          <input
+            type="number"
+            min={0}
+            step={1000}
+            value={amount || ''}
+            onChange={(e) => setAmount(Math.max(0, Number(e.target.value)))}
+            placeholder="e.g. 10 000"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+      </div>
+
+      {impact && amount <= selectedDebt.balance && (
+        <div className="rounded-md bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 p-4">
+          <p className="text-xs font-semibold text-amber-700 dark:text-amber-400 mb-2">
+            Impact of paying {formatCurrency(amount)} extra on "{selectedDebt.name}"
+          </p>
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs">
+            <div>
+              <dt className="text-amber-600 dark:text-amber-500">Interest saved</dt>
+              <dd className="font-semibold text-green-700 dark:text-green-400 text-sm">
+                {formatCurrency(impact.interestSaved)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-amber-600 dark:text-amber-500">Time saved</dt>
+              <dd className="font-semibold text-green-700 dark:text-green-400 text-sm">
+                {impact.monthsSaved > 0 ? formatDuration(impact.monthsSaved) : '—'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-amber-600 dark:text-amber-500">New payoff date</dt>
+              <dd className="font-semibold text-amber-800 dark:text-amber-300 text-sm">
+                {formatPayoffDate(impact.newPayoffDate)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-amber-600 dark:text-amber-500">Remaining balance</dt>
+              <dd className="font-semibold text-amber-800 dark:text-amber-300 text-sm">
+                {formatCurrency(Math.max(0, selectedDebt.balance - amount))}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      )}
+
+      {amount > selectedDebt.balance && (
+        <p className="text-xs text-red-500 dark:text-red-400">
+          Extra payment exceeds the current balance of {formatCurrency(selectedDebt.balance)}.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/PayoffChart.tsx
+++ b/src/components/PayoffChart.tsx
@@ -59,11 +59,11 @@ export default function PayoffChart({ debts }: PayoffChartProps) {
     typeof value === 'number' ? formatCurrency(value) : String(value ?? '')
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-5">
-      <h2 className="text-sm font-semibold text-gray-700 mb-4">Balance over time</h2>
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-5">
+      <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-4">Balance over time</h2>
       <ResponsiveContainer width="100%" height={300}>
         <LineChart data={data} margin={{ top: 4, right: 16, left: 8, bottom: 4 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
           <XAxis
             dataKey="month"
             tick={{ fontSize: 11 }}

--- a/src/components/StrategyComparison.tsx
+++ b/src/components/StrategyComparison.tsx
@@ -1,0 +1,119 @@
+import { calculateStrategy, formatCurrency, formatDuration } from '../utils/calculations'
+import type { Debt } from '../types/debt'
+
+interface StrategyComparisonProps {
+  debts: Debt[]
+}
+
+function formatPayoffDate(yyyyMM: string): string {
+  if (!yyyyMM) return '—'
+  const [year, month] = yyyyMM.split('-').map(Number)
+  return new Date(year, month - 1).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })
+}
+
+export default function StrategyComparison({ debts }: StrategyComparisonProps) {
+  if (debts.length < 2) return null
+
+  const avalanche = calculateStrategy(debts, 'avalanche')
+  const snowball = calculateStrategy(debts, 'snowball')
+  const interestDiff = snowball.totalInterestPaid - avalanche.totalInterestPaid
+  const monthsDiff = snowball.monthsToPayoff - avalanche.monthsToPayoff
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-5">
+      <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+        Payoff strategy comparison
+      </h2>
+      <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
+        Based on your current total monthly budget of{' '}
+        <span className="font-medium text-gray-600 dark:text-gray-400">
+          {formatCurrency(debts.reduce((s, d) => s + d.monthlyPayment, 0))}
+        </span>
+      </p>
+
+      <div className="grid grid-cols-2 gap-4">
+        {/* Avalanche */}
+        <div className="rounded-md border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/40 p-4">
+          <div className="flex items-center gap-1.5 mb-3">
+            <span className="text-base">🏔</span>
+            <span className="text-sm font-semibold text-indigo-700 dark:text-indigo-400">Avalanche</span>
+          </div>
+          <p className="text-xs text-indigo-600 dark:text-indigo-500 mb-3">
+            Highest interest rate first — minimises total interest paid.
+          </p>
+          <dl className="space-y-1.5 text-xs">
+            <Row label="Total interest" value={formatCurrency(avalanche.totalInterestPaid)} />
+            <Row label="Time to debt-free" value={formatDuration(avalanche.monthsToPayoff)} />
+            <Row label="Debt-free date" value={formatPayoffDate(avalanche.payoffDate)} />
+          </dl>
+          <div className="mt-3 pt-3 border-t border-indigo-200 dark:border-indigo-800">
+            <p className="text-xs text-indigo-500 dark:text-indigo-500 font-medium">Payoff order:</p>
+            <ol className="mt-1 space-y-0.5">
+              {avalanche.payoffOrder.map((name, i) => (
+                <li key={name} className="text-xs text-indigo-700 dark:text-indigo-400">
+                  {i + 1}. {name}
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+
+        {/* Snowball */}
+        <div className="rounded-md border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 p-4">
+          <div className="flex items-center gap-1.5 mb-3">
+            <span className="text-base">⛄</span>
+            <span className="text-sm font-semibold text-emerald-700 dark:text-emerald-400">Snowball</span>
+          </div>
+          <p className="text-xs text-emerald-600 dark:text-emerald-500 mb-3">
+            Lowest balance first — faster early wins for motivation.
+          </p>
+          <dl className="space-y-1.5 text-xs">
+            <Row label="Total interest" value={formatCurrency(snowball.totalInterestPaid)} />
+            <Row label="Time to debt-free" value={formatDuration(snowball.monthsToPayoff)} />
+            <Row label="Debt-free date" value={formatPayoffDate(snowball.payoffDate)} />
+          </dl>
+          <div className="mt-3 pt-3 border-t border-emerald-200 dark:border-emerald-800">
+            <p className="text-xs text-emerald-500 dark:text-emerald-500 font-medium">Payoff order:</p>
+            <ol className="mt-1 space-y-0.5">
+              {snowball.payoffOrder.map((name, i) => (
+                <li key={name} className="text-xs text-emerald-700 dark:text-emerald-400">
+                  {i + 1}. {name}
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      </div>
+
+      {/* Verdict */}
+      {interestDiff !== 0 && (
+        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+          Avalanche saves{' '}
+          <span className="font-semibold text-gray-700 dark:text-gray-200">
+            {formatCurrency(Math.abs(interestDiff))}
+          </span>{' '}
+          in interest
+          {monthsDiff !== 0 && (
+            <>
+              {' '}and{' '}
+              <span className="font-semibold text-gray-700 dark:text-gray-200">
+                {formatDuration(Math.abs(monthsDiff))}
+              </span>{' '}
+              {monthsDiff > 0 ? 'faster' : 'slower'}
+            </>
+          )}{' '}
+          compared to snowball.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <dt className="text-gray-500 dark:text-gray-400">{label}</dt>
+      <dd className="font-medium text-gray-800 dark:text-gray-200">{value}</dd>
+    </div>
+  )
+}

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,5 +1,23 @@
 import type { Debt, DebtPayoffPlan, PayoffMonth } from '../types/debt'
 
+export type Strategy = 'avalanche' | 'snowball'
+
+export interface StrategyResult {
+  strategy: Strategy
+  totalInterestPaid: number
+  totalPaid: number
+  monthsToPayoff: number
+  payoffDate: string
+  payoffOrder: string[] // debt names in the order they are paid off
+}
+
+export interface ExtraPaymentImpact {
+  debtId: string
+  interestSaved: number
+  monthsSaved: number
+  newPayoffDate: string
+}
+
 /**
  * Calculate the full amortization schedule for a single debt.
  */
@@ -69,6 +87,89 @@ export function formatCurrency(
     currency,
     maximumFractionDigits: 0,
   }).format(amount)
+}
+
+/**
+ * Simulate paying off multiple debts using avalanche or snowball strategy.
+ * Total monthly budget = sum of all current monthlyPayments.
+ * Minimums are paid on all debts; extra goes to the priority debt.
+ * When a debt is cleared its freed payment cascades to the next priority debt.
+ */
+export function calculateStrategy(debts: Debt[], strategy: Strategy): StrategyResult {
+  if (debts.length === 0) {
+    return { strategy, totalInterestPaid: 0, totalPaid: 0, monthsToPayoff: 0, payoffDate: '', payoffOrder: [] }
+  }
+
+  const budget = debts.reduce((sum, d) => sum + d.monthlyPayment, 0)
+
+  type DebtState = { id: string; name: string; balance: number; rate: number; minimum: number }
+  const states: DebtState[] = debts.map((d) => ({
+    id: d.id,
+    name: d.name,
+    balance: d.balance,
+    rate: d.interestRate,
+    minimum: d.minimumPayment,
+  }))
+
+  let month = 0
+  let totalInterest = 0
+  let totalPaid = 0
+  const payoffOrder: string[] = []
+  const startDate = new Date()
+
+  while (states.some((s) => s.balance > 0.005) && month < 1200) {
+    month++
+    const active = states.filter((s) => s.balance > 0.005)
+    const totalMinimums = active.reduce((sum, s) => sum + s.minimum, 0)
+    const extra = Math.max(0, budget - totalMinimums)
+
+    // Priority debt for the extra payment
+    const priority = [...active].sort((a, b) =>
+      strategy === 'avalanche' ? b.rate - a.rate : a.balance - b.balance
+    )[0]
+
+    for (const s of states) {
+      if (s.balance <= 0.005) continue
+      const interest = s.balance * (s.rate / 100 / 12)
+      totalInterest += interest
+      let payment = s.minimum + (s.id === priority.id ? extra : 0)
+      payment = Math.min(payment, s.balance + interest)
+      totalPaid += payment
+      s.balance = Math.max(0, s.balance - (payment - interest))
+      if (s.balance <= 0.005 && !payoffOrder.includes(s.name)) {
+        payoffOrder.push(s.name)
+      }
+    }
+  }
+
+  const payoffDate = new Date(startDate)
+  payoffDate.setMonth(startDate.getMonth() + month)
+
+  return {
+    strategy,
+    totalInterestPaid: totalInterest,
+    totalPaid,
+    monthsToPayoff: month,
+    payoffDate: payoffDate.toISOString().slice(0, 7),
+    payoffOrder,
+  }
+}
+
+/**
+ * Calculate the impact of a one-time lump-sum payment applied to a debt's balance.
+ */
+export function calculateExtraPaymentImpact(debt: Debt, extraAmount: number): ExtraPaymentImpact {
+  const original = calculatePayoffPlan(debt)
+  const modified = calculatePayoffPlan({
+    ...debt,
+    balance: Math.max(0, debt.balance - extraAmount),
+  })
+  return {
+    debtId: debt.id,
+    interestSaved: original.totalInterestPaid - modified.totalInterestPaid,
+    monthsSaved: original.monthsToPayoff - modified.monthsToPayoff,
+    newPayoffDate: modified.payoffDate,
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

**Avalanche vs Snowball comparison (#11)**
- New `calculateStrategy()` in `calculations.ts` — simulates paying off all debts together, cascading freed payments as each debt clears
- `StrategyComparison` component on the Dashboard shows both strategies side by side: total interest, time to debt-free, and the order debts get paid off
- Only visible when there are 2+ debts

**One-time payment simulator (#12)**
- New `calculateExtraPaymentImpact()` pure function
- `ExtraPaymentSimulator` component: pick a debt, enter a lump sum, see interest saved, months saved, and new payoff date
- Read-only — does not modify stored debt data

**Dark mode (#13)**
- `dark:` Tailwind variants added throughout: App, Dashboard, DebtCard, DebtForm, PayoffChart, StrategyComparison, ExtraPaymentSimulator
- Respects `prefers-color-scheme` automatically via Tailwind

Closes #11, closes #12, closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)