### PR TITLE
feat: payment tracking with actual vs planned comparison

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import Dashboard from './components/Dashboard'
 import DebtForm from './components/DebtForm'
+import PaymentsPage from './components/PaymentsPage'
 import type { Debt } from './types/debt'
 
-type Tab = 'dashboard' | 'add-debt'
+type Tab = 'dashboard' | 'add-debt' | 'payments'
 
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>('dashboard')
@@ -20,7 +21,7 @@ function App() {
   }
 
   const handleTabChange = (tab: Tab) => {
-    if (tab === 'dashboard') setEditingDebt(null)
+    if (tab !== 'add-debt') setEditingDebt(null)
     setActiveTab(tab)
   }
 
@@ -39,26 +40,19 @@ function App() {
 
             {/* Nav tabs */}
             <div className="flex gap-1">
-              <button
-                onClick={() => handleTabChange('dashboard')}
-                className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
-                  activeTab === 'dashboard'
-                    ? 'bg-gray-700 text-white'
-                    : 'text-gray-300 hover:bg-gray-800 hover:text-white'
-                }`}
-              >
-                Dashboard
-              </button>
-              <button
-                onClick={() => handleTabChange('add-debt')}
-                className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
-                  activeTab === 'add-debt'
-                    ? 'bg-gray-700 text-white'
-                    : 'text-gray-300 hover:bg-gray-800 hover:text-white'
-                }`}
-              >
-                {addDebtLabel}
-              </button>
+              {(['dashboard', 'payments', 'add-debt'] as const).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => handleTabChange(tab)}
+                  className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+                    activeTab === tab
+                      ? 'bg-gray-700 text-white'
+                      : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                  }`}
+                >
+                  {tab === 'add-debt' ? addDebtLabel : tab.charAt(0).toUpperCase() + tab.slice(1)}
+                </button>
+              ))}
             </div>
           </div>
         </div>
@@ -66,12 +60,14 @@ function App() {
 
       {/* Main content */}
       <main className="mx-auto max-w-5xl px-4 py-6">
-        {activeTab === 'dashboard' ? (
+        {activeTab === 'dashboard' && (
           <Dashboard
             onAddDebt={() => handleTabChange('add-debt')}
             onEditDebt={handleEditDebt}
           />
-        ) : (
+        )}
+        {activeTab === 'payments' && <PaymentsPage />}
+        {activeTab === 'add-debt' && (
           <DebtForm
             initialData={editingDebt ?? undefined}
             onSave={handleFormSave}

--- a/src/components/DebtCard.tsx
+++ b/src/components/DebtCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useDebtStore } from '../store/useDebtStore'
-import { calculatePayoffPlan, formatCurrency, formatDuration } from '../utils/calculations'
+import { usePaymentStore } from '../store/usePaymentStore'
+import { calculatePayoffPlan, formatCurrency, formatDuration, getActualBalance, getPlannedBalanceAtDate } from '../utils/calculations'
 import type { Debt } from '../types/debt'
 
 interface DebtCardProps {
@@ -51,10 +52,16 @@ function AmortizationTable({ debt }: { debt: Debt }) {
 
 export default function DebtCard({ debt, onEdit }: DebtCardProps) {
   const removeDebt = useDebtStore((s) => s.removeDebt)
+  const payments = usePaymentStore((s) => s.getPaymentsForDebt(debt.id))
   const [confirming, setConfirming] = useState(false)
   const [showSchedule, setShowSchedule] = useState(false)
 
   const plan = calculatePayoffPlan(debt)
+
+  const today = new Date().toISOString().slice(0, 10)
+  const actualBalance = payments.length > 0 ? getActualBalance(debt, payments) : null
+  const plannedBalance = payments.length > 0 ? getPlannedBalanceAtDate(debt, today) : null
+  const diff = actualBalance !== null && plannedBalance !== null ? actualBalance - plannedBalance : null
 
   return (
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-5">
@@ -97,6 +104,26 @@ export default function DebtCard({ debt, onEdit }: DebtCardProps) {
               </button>
             </div>
           </div>
+
+          {diff !== null && (
+            <div
+              className={[
+                'mb-4 text-xs font-medium px-3 py-1.5 rounded-md',
+                diff < -0.5
+                  ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                  : diff > 0.5
+                  ? 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                  : 'bg-gray-50 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+              ].join(' ')}
+            >
+              {diff < -0.5
+                ? `${formatCurrency(Math.abs(diff))} ahead of schedule`
+                : diff > 0.5
+                ? `${formatCurrency(diff)} behind schedule`
+                : 'On track'}
+              {' '}— actual balance: {formatCurrency(actualBalance!)}
+            </div>
+          )}
 
           <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
             <Stat label="Balance" value={formatCurrency(debt.balance)} />

--- a/src/components/PaymentForm.tsx
+++ b/src/components/PaymentForm.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react'
+import { usePaymentStore } from '../store/usePaymentStore'
+import type { Debt } from '../types/debt'
+import type { PaymentType } from '../types/payment'
+
+interface PaymentFormProps {
+  debt: Debt
+  onClose: () => void
+}
+
+const today = () => new Date().toISOString().slice(0, 10)
+
+export default function PaymentForm({ debt, onClose }: PaymentFormProps) {
+  const addPayment = usePaymentStore((s) => s.addPayment)
+  const [type, setType] = useState<PaymentType>('payment')
+  const [amount, setAmount] = useState('')
+  const [date, setDate] = useState(today())
+  const [note, setNote] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const parsed = Number(amount)
+    if (!parsed || parsed <= 0) {
+      setError('Amount must be greater than 0')
+      return
+    }
+    addPayment(debt.id, date, parsed, type, note.trim() || undefined)
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md mx-4 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+          Register transaction
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">{debt.name}</p>
+
+        <form onSubmit={handleSubmit} noValidate className="space-y-4">
+          {/* Type toggle */}
+          <div className="flex rounded-md overflow-hidden border border-gray-300 dark:border-gray-600 text-sm font-medium">
+            {(['payment', 'charge'] as PaymentType[]).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setType(t)}
+                className={[
+                  'flex-1 py-2 transition-colors capitalize',
+                  type === t
+                    ? t === 'payment'
+                      ? 'bg-green-600 text-white'
+                      : 'bg-red-500 text-white'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600',
+                ].join(' ')}
+              >
+                {t === 'payment' ? 'Payment (reduces debt)' : 'Charge (increases debt)'}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Amount (NOK)
+              </label>
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={amount}
+                onChange={(e) => { setAmount(e.target.value); setError(null) }}
+                placeholder="e.g. 2000"
+                className={inputCls(!!error)}
+                autoFocus
+              />
+              {error && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</p>}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Date
+              </label>
+              <input
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className={inputCls(false)}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Note (optional)
+            </label>
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="e.g. Monthly payment"
+              className={inputCls(false)}
+            />
+          </div>
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="submit"
+              className={[
+                'flex-1 py-2 rounded-md text-sm font-medium text-white transition-colors',
+                type === 'payment'
+                  ? 'bg-green-600 hover:bg-green-700'
+                  : 'bg-red-500 hover:bg-red-600',
+              ].join(' ')}
+            >
+              {type === 'payment' ? 'Register payment' : 'Register charge'}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 py-2 rounded-md text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function inputCls(hasError: boolean) {
+  return [
+    'w-full rounded-md border px-3 py-2 text-sm',
+    'text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700',
+    'focus:outline-none focus:ring-2 focus:ring-indigo-500',
+    hasError ? 'border-red-400 dark:border-red-600' : 'border-gray-300 dark:border-gray-600',
+  ].join(' ')
+}

--- a/src/components/PaymentsPage.tsx
+++ b/src/components/PaymentsPage.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react'
+import { useDebtStore } from '../store/useDebtStore'
+import { usePaymentStore } from '../store/usePaymentStore'
+import { formatCurrency, getActualBalance, getPlannedBalanceAtDate } from '../utils/calculations'
+import type { Debt } from '../types/debt'
+import type { Payment } from '../types/payment'
+import PaymentForm from './PaymentForm'
+
+export default function PaymentsPage() {
+  const debts = useDebtStore((s) => s.debts)
+  const [formDebt, setFormDebt] = useState<Debt | null>(null)
+
+  if (debts.length === 0) {
+    return (
+      <div className="text-center py-16 text-gray-500 dark:text-gray-400">
+        <p className="text-lg font-medium">No debts yet</p>
+        <p className="text-sm mt-1">Add a debt first to start tracking payments.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Payment tracking</h2>
+      </div>
+
+      {debts.map((debt) => (
+        <DebtPaymentRow key={debt.id} debt={debt} onAddPayment={() => setFormDebt(debt)} />
+      ))}
+
+      {formDebt && (
+        <PaymentForm debt={formDebt} onClose={() => setFormDebt(null)} />
+      )}
+    </div>
+  )
+}
+
+function DebtPaymentRow({ debt, onAddPayment }: { debt: Debt; onAddPayment: () => void }) {
+  const payments = usePaymentStore((s) => s.getPaymentsForDebt(debt.id))
+  const removePayment = usePaymentStore((s) => s.removePayment)
+  const [expanded, setExpanded] = useState(false)
+
+  const today = new Date().toISOString().slice(0, 10)
+  const actualBalance = getActualBalance(debt, payments)
+  const plannedBalance = getPlannedBalanceAtDate(debt, today)
+  const diff = actualBalance - plannedBalance // positive = behind, negative = ahead
+
+  const hasDiff = payments.length > 0
+  const ahead = diff < -0.5
+  const behind = diff > 0.5
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+      {/* Header row */}
+      <div className="p-4 flex flex-col sm:flex-row sm:items-center gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-semibold text-gray-900 dark:text-gray-100 truncate">{debt.name}</span>
+            {hasDiff && (
+              <span
+                className={[
+                  'text-xs font-medium px-2 py-0.5 rounded-full',
+                  ahead
+                    ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400'
+                    : behind
+                    ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400'
+                    : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+                ].join(' ')}
+              >
+                {ahead
+                  ? `${formatCurrency(Math.abs(diff))} ahead`
+                  : behind
+                  ? `${formatCurrency(diff)} behind`
+                  : 'on track'}
+              </span>
+            )}
+          </div>
+
+          <div className="mt-1 flex flex-wrap gap-x-4 gap-y-0.5 text-sm text-gray-500 dark:text-gray-400">
+            <span>
+              Actual: <span className="font-medium text-gray-900 dark:text-gray-100">{formatCurrency(actualBalance)}</span>
+            </span>
+            {hasDiff && (
+              <span>
+                Planned: <span className="font-medium text-gray-900 dark:text-gray-100">{formatCurrency(plannedBalance)}</span>
+              </span>
+            )}
+            {payments.length === 0 && (
+              <span className="italic text-gray-400 dark:text-gray-500">No payments recorded yet</span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex gap-2 shrink-0">
+          <button
+            onClick={onAddPayment}
+            className="px-3 py-1.5 text-sm font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+          >
+            + Add
+          </button>
+          {payments.length > 0 && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="px-3 py-1.5 text-sm font-medium rounded-md bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            >
+              {expanded ? 'Hide' : `History (${payments.length})`}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Payment history */}
+      {expanded && payments.length > 0 && (
+        <div className="border-t border-gray-100 dark:border-gray-700">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-900/40 text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide">
+                <th className="text-left px-4 py-2">Date</th>
+                <th className="text-left px-4 py-2">Type</th>
+                <th className="text-right px-4 py-2">Amount</th>
+                <th className="text-left px-4 py-2">Note</th>
+                <th className="px-4 py-2"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+              {[...payments]
+                .sort((a, b) => b.date.localeCompare(a.date))
+                .map((p) => (
+                  <PaymentRow key={p.id} payment={p} onRemove={() => removePayment(p.id)} />
+                ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PaymentRow({ payment, onRemove }: { payment: Payment; onRemove: () => void }) {
+  const [confirming, setConfirming] = useState(false)
+
+  return (
+    <tr className="text-gray-700 dark:text-gray-300">
+      <td className="px-4 py-2 tabular-nums">{payment.date}</td>
+      <td className="px-4 py-2">
+        <span
+          className={[
+            'text-xs font-medium px-2 py-0.5 rounded-full capitalize',
+            payment.type === 'payment'
+              ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400'
+              : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',
+          ].join(' ')}
+        >
+          {payment.type}
+        </span>
+      </td>
+      <td className="px-4 py-2 text-right tabular-nums">
+        <span className={payment.type === 'payment' ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}>
+          {payment.type === 'charge' ? '+' : '-'}{formatCurrency(payment.amount)}
+        </span>
+      </td>
+      <td className="px-4 py-2 text-gray-500 dark:text-gray-400">{payment.note ?? '—'}</td>
+      <td className="px-4 py-2 text-right">
+        {confirming ? (
+          <span className="inline-flex gap-2">
+            <button onClick={onRemove} className="text-red-600 dark:text-red-400 hover:underline text-xs">Yes, delete</button>
+            <button onClick={() => setConfirming(false)} className="text-gray-500 hover:underline text-xs">Cancel</button>
+          </span>
+        ) : (
+          <button
+            onClick={() => setConfirming(true)}
+            className="text-gray-400 hover:text-red-500 transition-colors text-xs"
+          >
+            Delete
+          </button>
+        )}
+      </td>
+    </tr>
+  )
+}

--- a/src/store/usePaymentStore.ts
+++ b/src/store/usePaymentStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { Payment, PaymentType } from '../types/payment'
+
+const generateId = () =>
+  Date.now().toString(36) + Math.random().toString(36).slice(2, 9)
+
+interface PaymentStore {
+  payments: Payment[]
+  addPayment: (debtId: string, date: string, amount: number, type: PaymentType, note?: string) => void
+  removePayment: (id: string) => void
+  getPaymentsForDebt: (debtId: string) => Payment[]
+}
+
+export const usePaymentStore = create<PaymentStore>()(
+  persist(
+    (set, get) => ({
+      payments: [],
+
+      addPayment: (debtId, date, amount, type, note) =>
+        set((state) => ({
+          payments: [
+            ...state.payments,
+            { id: generateId(), debtId, date, amount, type, note },
+          ],
+        })),
+
+      removePayment: (id) =>
+        set((state) => ({
+          payments: state.payments.filter((p) => p.id !== id),
+        })),
+
+      getPaymentsForDebt: (debtId) =>
+        get().payments.filter((p) => p.debtId === debtId),
+    }),
+    { name: 'debt-planner-payments' }
+  )
+)

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,0 +1,10 @@
+export type PaymentType = 'payment' | 'charge'
+
+export interface Payment {
+  id: string
+  debtId: string
+  date: string // ISO date string
+  amount: number // always positive; type determines effect on balance
+  type: PaymentType // 'payment' reduces balance, 'charge' increases it
+  note?: string
+}

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,4 +1,5 @@
 import type { Debt, DebtPayoffPlan, PayoffMonth } from '../types/debt'
+import type { Payment } from '../types/payment'
 
 export type Strategy = 'avalanche' | 'snowball'
 
@@ -170,6 +171,49 @@ export function calculateExtraPaymentImpact(debt: Debt, extraAmount: number): Ex
     monthsSaved: original.monthsToPayoff - modified.monthsToPayoff,
     newPayoffDate: modified.payoffDate,
   }
+}
+
+/**
+ * Compute the actual current balance of a debt after applying recorded payments and charges.
+ * Payments reduce the balance; charges increase it.
+ */
+export function getActualBalance(debt: Debt, payments: Payment[]): number {
+  const net = payments.reduce((sum, p) => {
+    return p.type === 'payment' ? sum - p.amount : sum + p.amount
+  }, 0)
+  return Math.max(0, debt.balance + net)
+}
+
+/**
+ * Return the planned balance from the amortization schedule at a given ISO date (YYYY-MM-DD).
+ * Returns the starting balance if the date is before any schedule entry.
+ */
+export function getPlannedBalanceAtDate(debt: Debt, isoDate: string): number {
+  const plan = calculatePayoffPlan(debt)
+  const targetMonth = isoDate.slice(0, 7) // YYYY-MM
+  const entry = [...plan.schedule].reverse().find((m) => m.date <= targetMonth)
+  return entry ? entry.remainingBalance : debt.balance
+}
+
+/**
+ * Build a series of { date, balance } points from recorded payments for chart rendering.
+ * Starts at debt.balance on debt.startDate and applies each payment chronologically.
+ */
+export function getActualBalanceSeries(
+  debt: Debt,
+  payments: Payment[]
+): { date: string; balance: number }[] {
+  const sorted = [...payments].sort((a, b) => a.date.localeCompare(b.date))
+  const series: { date: string; balance: number }[] = [
+    { date: debt.startDate.slice(0, 7), balance: debt.balance },
+  ]
+  let balance = debt.balance
+  for (const p of sorted) {
+    balance = p.type === 'payment' ? balance - p.amount : balance + p.amount
+    balance = Math.max(0, balance)
+    series.push({ date: p.date.slice(0, 7), balance })
+  }
+  return series
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a new **Payments** tab where users can register payments and debt charges for each debt
- Each debt row shows **actual balance vs planned balance** at today's date, with an ahead/behind badge
- **DebtCard** on the dashboard also shows the ahead/behind indicator when payments exist
- Payment history is expandable per debt and individual entries can be deleted

## New structure

- `src/types/payment.ts` — `Payment` type (`payment` reduces balance, `charge` increases it)
- `src/store/usePaymentStore.ts` — Zustand store, persisted to localStorage under `debt-planner-payments`
- `src/components/PaymentForm.tsx` — modal form with payment/charge toggle, amount, date, note
- `src/components/PaymentsPage.tsx` — per-debt rows with history table and delete
- `src/utils/calculations.ts` — `getActualBalance`, `getPlannedBalanceAtDate`, `getActualBalanceSeries` helpers

## Test plan

- [ ] Add a debt, go to Payments tab, register a payment — actual balance updates, badge shows ahead/behind
- [ ] Register a charge — actual balance increases
- [ ] Delete a payment — balance recalculates
- [ ] Verify DebtCard on dashboard shows the status badge
- [ ] Verify empty state when no debts exist
- [ ] Check dark mode styling throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)