### PR TITLE
feat: replace localStorage with SQLite backend via Hono API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# SQLite database
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# ── dev stage ─────────────────────────────────────────────────────────────────
+# ── dev stage (Vite only, no API) ─────────────────────────────────────────────
 FROM node:22-alpine AS dev
 WORKDIR /app
 COPY package*.json ./
@@ -7,7 +7,7 @@ COPY . .
 EXPOSE 5173
 CMD ["npm", "run", "dev"]
 
-# ── build stage ───────────────────────────────────────────────────────────────
+# ── build stage ────────────────────────────────────────────────────────────────
 FROM node:22-alpine AS build
 WORKDIR /app
 COPY package*.json ./
@@ -15,9 +15,24 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-# ── prod stage ────────────────────────────────────────────────────────────────
-FROM nginx:alpine AS prod
-COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+# ── prod stage (Hono API + static frontend) ────────────────────────────────────
+FROM node:22-alpine AS prod
+WORKDIR /app
+
+# Required for better-sqlite3 native module compilation
+RUN apk add --no-cache python3 make g++
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+COPY server/ ./server/
+COPY src/types/ ./src/types/
+COPY tsconfig.server.json ./
+
+RUN mkdir -p /app/data
+
+EXPOSE 3000
+ENV NODE_ENV=production
+
+CMD ["npx", "tsx", "server/index.ts"]

--- a/README.md
+++ b/README.md
@@ -33,19 +33,41 @@ A vertical reference line marks today. If you have made extra payments the forec
 
 ## Getting Started
 
+### Local development
+
+The app requires the Node/Hono API server to be running alongside the Vite dev server (which proxies `/api` calls to port 3000).
+
 ```bash
 npm install
+
+# Terminal 1 — API server (SQLite, auto-restarts on changes)
+npm run dev:server
+
+# Terminal 2 — Vite frontend (hot reload)
 npm run dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173).
+Open [http://localhost:5173](http://localhost:5173). Data is stored in `./data/db.sqlite`.
 
-To build for production:
+### Deploy to a VPS with Docker Compose
 
 ```bash
-npm run build
-npm run preview
+docker compose --profile prod up -d --build
 ```
+
+The app runs on port 3000. SQLite data is stored in a named Docker volume (`db-data`) and survives container rebuilds.
+
+To deploy an update:
+
+```bash
+docker compose --profile prod up -d --build
+```
+
+Docker Compose replaces the container but the `db-data` volume (and your data) is untouched.
+
+### Migrating existing browser data
+
+If you had data stored in the old localStorage-based version, a yellow banner will appear on first load. Click **Migrate now** to copy all debts and payments from the browser into the SQLite database, then clear the localStorage keys. The migration is idempotent — running it twice will not create duplicates.
 
 ## Project Structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 services:
+  # Local development — Vite dev server only (hot reload).
+  # Run the API separately: npm run dev:server
   app:
     build:
       context: .
@@ -11,11 +13,22 @@ services:
     environment:
       - NODE_ENV=development
 
+  # Production — Hono server serves both the API and the built frontend.
   app-prod:
     build:
       context: .
       target: prod
     ports:
-      - "8080:80"
+      - "3000:3000"
+    volumes:
+      - db-data:/app/data
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DB_PATH=/app/data/db.sqlite
+    restart: unless-stopped
     profiles:
       - prod
+
+volumes:
+  db-data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "debtpaymentplanner",
       "version": "0.0.0",
       "dependencies": {
+        "@hono/node-server": "^1.19.11",
+        "better-sqlite3": "^12.8.0",
+        "hono": "^4.12.8",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "recharts": "^3.8.0",
@@ -16,6 +19,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.2.2",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -25,6 +29,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "tailwindcss": "^4.2.2",
+        "tsx": "^4.21.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
@@ -304,6 +309,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -459,6 +906,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1183,6 +1642,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -1687,6 +2156,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.9",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.9.tgz",
@@ -1698,6 +2187,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1743,6 +2266,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/callsites": {
@@ -1792,6 +2339,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2003,6 +2556,30 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2014,7 +2591,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2026,6 +2602,15 @@
       "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -2050,6 +2635,48 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2264,6 +2891,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2316,6 +2952,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2354,6 +2996,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2378,6 +3026,25 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -2439,6 +3106,35 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2485,6 +3181,18 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -2930,6 +3638,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2942,6 +3662,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2969,6 +3704,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2976,12 +3717,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3115,6 +3889,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3125,6 +3926,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3133,6 +3944,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -3184,6 +4019,20 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/recharts": {
@@ -3247,6 +4096,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
@@ -3288,6 +4147,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3327,6 +4206,51 @@
         "node": ">=8"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3335,6 +4259,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3384,6 +4317,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -3427,6 +4388,38 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3535,6 +4528,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
@@ -3661,6 +4660,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:server": "tsx watch server/index.ts",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
+    "better-sqlite3": "^12.8.0",
+    "hono": "^4.12.8",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "recharts": "^3.8.0",
@@ -18,6 +22,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.2",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -27,6 +32,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1"

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,40 @@
+import Database from 'better-sqlite3'
+import path from 'path'
+import fs from 'fs'
+
+const DB_PATH = process.env.DB_PATH ?? path.join(process.cwd(), 'data', 'db.sqlite')
+
+// Ensure the data directory exists
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true })
+
+const db = new Database(DB_PATH)
+
+db.pragma('journal_mode = WAL')
+db.pragma('foreign_keys = ON')
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS debts (
+    id                      TEXT PRIMARY KEY,
+    debt_type               TEXT NOT NULL DEFAULT 'installment',
+    name                    TEXT NOT NULL,
+    balance                 REAL NOT NULL,
+    interest_rate           REAL NOT NULL,
+    minimum_payment_percent REAL,
+    minimum_payment         REAL NOT NULL,
+    monthly_payment         REAL NOT NULL,
+    start_date              TEXT NOT NULL,
+    notes                   TEXT,
+    color                   TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS payments (
+    id       TEXT PRIMARY KEY,
+    debt_id  TEXT NOT NULL REFERENCES debts(id) ON DELETE CASCADE,
+    date     TEXT NOT NULL,
+    amount   REAL NOT NULL,
+    type     TEXT NOT NULL CHECK (type IN ('payment', 'charge')),
+    note     TEXT
+  );
+`)
+
+export default db

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,70 @@
+import { Hono } from 'hono'
+import { serve } from '@hono/node-server'
+import { serveStatic } from '@hono/node-server/serve-static'
+import db from './db.js'
+import debtsRouter from './routes/debts.js'
+import paymentsRouter from './routes/payments.js'
+import type { Debt } from '../src/types/debt.js'
+import type { Payment } from '../src/types/payment.js'
+
+const app = new Hono()
+
+app.route('/api/debts', debtsRouter)
+app.route('/api/payments', paymentsRouter)
+
+// One-time migration endpoint: accepts the raw Zustand localStorage state
+// and inserts all records, skipping any that already exist.
+app.post('/api/migrate', async (c) => {
+  const body = await c.req.json<{ debts: Debt[]; payments: Payment[] }>()
+
+  const insertDebt = db.prepare(`
+    INSERT OR IGNORE INTO debts
+      (id, debt_type, name, balance, interest_rate, minimum_payment_percent, minimum_payment, monthly_payment, start_date, notes, color)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertPayment = db.prepare(`
+    INSERT OR IGNORE INTO payments (id, debt_id, date, amount, type, note)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `)
+
+  const migrate = db.transaction(() => {
+    let debtsInserted = 0
+    let paymentsInserted = 0
+
+    for (const d of body.debts ?? []) {
+      const result = insertDebt.run(
+        d.id,
+        d.debtType ?? 'installment',
+        d.name,
+        d.balance,
+        d.interestRate,
+        d.minimumPaymentPercent ?? null,
+        d.minimumPayment,
+        d.monthlyPayment,
+        d.startDate,
+        d.notes ?? null,
+        d.color ?? null,
+      )
+      debtsInserted += Number(result.changes)
+    }
+
+    for (const p of body.payments ?? []) {
+      const result = insertPayment.run(p.id, p.debtId, p.date, p.amount, p.type, p.note ?? null)
+      paymentsInserted += Number(result.changes)
+    }
+
+    return { debtsInserted, paymentsInserted }
+  })
+
+  const result = migrate()
+  return c.json({ ok: true, ...result })
+})
+
+// Serve the built Vite frontend for all non-API routes
+app.use('/*', serveStatic({ root: './dist' }))
+app.get('/*', serveStatic({ path: './dist/index.html' }))
+
+const port = Number(process.env.PORT ?? 3000)
+console.log(`Server running on http://localhost:${port}`)
+
+serve({ fetch: app.fetch, port })

--- a/server/routes/debts.ts
+++ b/server/routes/debts.ts
@@ -1,0 +1,87 @@
+import { Hono } from 'hono'
+import db from '../db.js'
+import type { Debt } from '../../src/types/debt.js'
+
+const router = new Hono()
+
+function rowToDebt(row: Record<string, unknown>): Debt {
+  return {
+    id: row.id as string,
+    debtType: (row.debt_type as Debt['debtType']) ?? 'installment',
+    name: row.name as string,
+    balance: row.balance as number,
+    interestRate: row.interest_rate as number,
+    minimumPaymentPercent: row.minimum_payment_percent as number | undefined,
+    minimumPayment: row.minimum_payment as number,
+    monthlyPayment: row.monthly_payment as number,
+    startDate: row.start_date as string,
+    notes: row.notes as string | undefined,
+    color: row.color as string | undefined,
+  }
+}
+
+router.get('/', (c) => {
+  const rows = db.prepare('SELECT * FROM debts ORDER BY rowid').all() as Record<string, unknown>[]
+  return c.json({ debts: rows.map(rowToDebt) })
+})
+
+router.post('/', async (c) => {
+  const body = await c.req.json<Omit<Debt, 'id'> & { id?: string }>()
+  const id = body.id ?? (Date.now().toString(36) + Math.random().toString(36).slice(2, 9))
+  db.prepare(`
+    INSERT INTO debts (id, debt_type, name, balance, interest_rate, minimum_payment_percent, minimum_payment, monthly_payment, start_date, notes, color)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    body.debtType ?? 'installment',
+    body.name,
+    body.balance,
+    body.interestRate,
+    body.minimumPaymentPercent ?? null,
+    body.minimumPayment,
+    body.monthlyPayment,
+    body.startDate,
+    body.notes ?? null,
+    body.color ?? null,
+  )
+  const row = db.prepare('SELECT * FROM debts WHERE id = ?').get(id) as Record<string, unknown>
+  return c.json({ debt: rowToDebt(row) }, 201)
+})
+
+router.put('/:id', async (c) => {
+  const id = c.req.param('id')
+  const body = await c.req.json<Partial<Debt>>()
+  const existing = db.prepare('SELECT * FROM debts WHERE id = ?').get(id) as Record<string, unknown> | undefined
+  if (!existing) return c.json({ error: 'Not found' }, 404)
+
+  const merged = { ...rowToDebt(existing), ...body }
+  db.prepare(`
+    UPDATE debts SET
+      debt_type = ?, name = ?, balance = ?, interest_rate = ?,
+      minimum_payment_percent = ?, minimum_payment = ?, monthly_payment = ?,
+      start_date = ?, notes = ?, color = ?
+    WHERE id = ?
+  `).run(
+    merged.debtType ?? 'installment',
+    merged.name,
+    merged.balance,
+    merged.interestRate,
+    merged.minimumPaymentPercent ?? null,
+    merged.minimumPayment,
+    merged.monthlyPayment,
+    merged.startDate,
+    merged.notes ?? null,
+    merged.color ?? null,
+    id,
+  )
+  const row = db.prepare('SELECT * FROM debts WHERE id = ?').get(id) as Record<string, unknown>
+  return c.json({ debt: rowToDebt(row) })
+})
+
+router.delete('/:id', (c) => {
+  const id = c.req.param('id')
+  db.prepare('DELETE FROM debts WHERE id = ?').run(id)
+  return c.json({ ok: true })
+})
+
+export default router

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -1,0 +1,40 @@
+import { Hono } from 'hono'
+import db from '../db.js'
+import type { Payment } from '../../src/types/payment.js'
+
+const router = new Hono()
+
+function rowToPayment(row: Record<string, unknown>): Payment {
+  return {
+    id: row.id as string,
+    debtId: row.debt_id as string,
+    date: row.date as string,
+    amount: row.amount as number,
+    type: row.type as Payment['type'],
+    note: row.note as string | undefined,
+  }
+}
+
+router.get('/', (c) => {
+  const rows = db.prepare('SELECT * FROM payments ORDER BY date, rowid').all() as Record<string, unknown>[]
+  return c.json({ payments: rows.map(rowToPayment) })
+})
+
+router.post('/', async (c) => {
+  const body = await c.req.json<Omit<Payment, 'id'> & { id?: string }>()
+  const id = body.id ?? (Date.now().toString(36) + Math.random().toString(36).slice(2, 9))
+  db.prepare(`
+    INSERT INTO payments (id, debt_id, date, amount, type, note)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(id, body.debtId, body.date, body.amount, body.type, body.note ?? null)
+  const row = db.prepare('SELECT * FROM payments WHERE id = ?').get(id) as Record<string, unknown>
+  return c.json({ payment: rowToPayment(row) }, 201)
+})
+
+router.delete('/:id', (c) => {
+  const id = c.req.param('id')
+  db.prepare('DELETE FROM payments WHERE id = ?').run(id)
+  return c.json({ ok: true })
+})
+
+export default router

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Dashboard from './components/Dashboard'
 import DebtForm from './components/DebtForm'
 import PaymentsPage from './components/PaymentsPage'
+import MigrationBanner from './components/MigrationBanner'
+import { useDebtStore } from './store/useDebtStore'
+import { usePaymentStore } from './store/usePaymentStore'
 import type { Debt } from './types/debt'
 
 type Tab = 'dashboard' | 'add-debt' | 'payments'
@@ -9,6 +12,13 @@ type Tab = 'dashboard' | 'add-debt' | 'payments'
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>('dashboard')
   const [editingDebt, setEditingDebt] = useState<Debt | null>(null)
+  const loadDebts = useDebtStore((s) => s.load)
+  const loadPayments = usePaymentStore((s) => s.load)
+
+  useEffect(() => {
+    loadDebts()
+    loadPayments()
+  }, [loadDebts, loadPayments])
 
   const handleEditDebt = (debt: Debt) => {
     setEditingDebt(debt)
@@ -29,6 +39,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900">
+      <MigrationBanner />
       {/* Navigation bar */}
       <nav className="bg-gray-900 text-white">
         <div className="mx-auto max-w-5xl px-4">

--- a/src/components/DebtForm.tsx
+++ b/src/components/DebtForm.tsx
@@ -89,16 +89,16 @@ export default function DebtForm({ initialData, onSave }: DebtFormProps) {
     return Object.keys(e).length === 0
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!validate()) return
 
     if (initialData) {
-      updateDebt(initialData.id, form)
+      await updateDebt(initialData.id, form)
       setSuccess('Debt updated!')
       setTimeout(() => onSave?.(), 800)
     } else {
-      addDebt(form)
+      await addDebt(form)
       setSuccess('Debt added!')
       setForm(emptyForm())
       setTimeout(() => onSave?.(), 800)

--- a/src/components/MigrationBanner.tsx
+++ b/src/components/MigrationBanner.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect } from 'react'
+import { useDebtStore } from '../store/useDebtStore'
+import { usePaymentStore } from '../store/usePaymentStore'
+import type { Debt } from '../types/debt'
+import type { Payment } from '../types/payment'
+
+const LS_DEBT_KEY = 'debt-planner'
+const LS_PAYMENT_KEY = 'debt-planner-payments'
+
+function readLegacyData(): { debts: Debt[]; payments: Payment[] } | null {
+  try {
+    const debtRaw = localStorage.getItem(LS_DEBT_KEY)
+    const paymentRaw = localStorage.getItem(LS_PAYMENT_KEY)
+    if (!debtRaw && !paymentRaw) return null
+
+    const debts: Debt[] = debtRaw
+      ? (JSON.parse(debtRaw) as { state?: { debts?: Debt[] } }).state?.debts ?? []
+      : []
+    const payments: Payment[] = paymentRaw
+      ? (JSON.parse(paymentRaw) as { state?: { payments?: Payment[] } }).state?.payments ?? []
+      : []
+
+    if (debts.length === 0 && payments.length === 0) return null
+    return { debts, payments }
+  } catch {
+    return null
+  }
+}
+
+export default function MigrationBanner() {
+  const [legacy, setLegacy] = useState<{ debts: Debt[]; payments: Payment[] } | null>(null)
+  const [status, setStatus] = useState<'idle' | 'migrating' | 'done' | 'error'>('idle')
+  const loadDebts = useDebtStore((s) => s.load)
+  const loadPayments = usePaymentStore((s) => s.load)
+
+  useEffect(() => {
+    setLegacy(readLegacyData())
+  }, [])
+
+  if (!legacy || status === 'done') return null
+
+  const handleMigrate = async () => {
+    setStatus('migrating')
+    try {
+      const res = await fetch('/api/migrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(legacy),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const { debtsInserted, paymentsInserted } = await res.json() as {
+        debtsInserted: number
+        paymentsInserted: number
+      }
+      localStorage.removeItem(LS_DEBT_KEY)
+      localStorage.removeItem(LS_PAYMENT_KEY)
+      await Promise.all([loadDebts(), loadPayments()])
+      console.log(`Migrated ${debtsInserted} debts and ${paymentsInserted} payments`)
+      setStatus('done')
+    } catch (e) {
+      console.error('Migration failed', e)
+      setStatus('error')
+    }
+  }
+
+  const handleDismiss = () => {
+    localStorage.removeItem(LS_DEBT_KEY)
+    localStorage.removeItem(LS_PAYMENT_KEY)
+    setLegacy(null)
+  }
+
+  return (
+    <div className="bg-amber-50 dark:bg-amber-900/30 border-b border-amber-200 dark:border-amber-700 px-4 py-3">
+      <div className="mx-auto max-w-5xl flex items-center justify-between gap-4 flex-wrap">
+        <div className="text-sm text-amber-800 dark:text-amber-300">
+          <span className="font-semibold">Local data found</span>
+          {' '}— {legacy.debts.length} debt{legacy.debts.length !== 1 ? 's' : ''} and{' '}
+          {legacy.payments.length} payment{legacy.payments.length !== 1 ? 's' : ''} stored in this
+          browser. Migrate to the database to keep your data.
+        </div>
+        <div className="flex gap-2 shrink-0">
+          {status === 'error' && (
+            <span className="text-sm text-red-600 dark:text-red-400 self-center">
+              Migration failed — check console
+            </span>
+          )}
+          <button
+            onClick={handleMigrate}
+            disabled={status === 'migrating'}
+            className="px-3 py-1.5 bg-amber-600 hover:bg-amber-700 disabled:opacity-60 text-white text-sm font-medium rounded-md transition-colors"
+          >
+            {status === 'migrating' ? 'Migrating…' : 'Migrate now'}
+          </button>
+          <button
+            onClick={handleDismiss}
+            className="px-3 py-1.5 border border-amber-400 dark:border-amber-600 text-amber-700 dark:text-amber-300 text-sm rounded-md hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+          >
+            Discard local data
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/store/useDebtStore.ts
+++ b/src/store/useDebtStore.ts
@@ -1,42 +1,57 @@
 import { create } from 'zustand'
+import type { Debt, DebtFormData } from '../types/debt'
 
 const generateId = () =>
   Date.now().toString(36) + Math.random().toString(36).slice(2, 9)
-import { persist } from 'zustand/middleware'
-import type { Debt, DebtFormData } from '../types/debt'
 
 interface DebtStore {
   debts: Debt[]
-  addDebt: (data: DebtFormData) => void
-  updateDebt: (id: string, data: Partial<DebtFormData>) => void
-  removeDebt: (id: string) => void
+  loading: boolean
+  error: string | null
+  load: () => Promise<void>
+  addDebt: (data: DebtFormData) => Promise<void>
+  updateDebt: (id: string, data: Partial<DebtFormData>) => Promise<void>
+  removeDebt: (id: string) => Promise<void>
 }
 
-export const useDebtStore = create<DebtStore>()(
-  persist(
-    (set) => ({
-      debts: [],
+export const useDebtStore = create<DebtStore>()((set) => ({
+  debts: [],
+  loading: false,
+  error: null,
 
-      addDebt: (data) =>
-        set((state) => ({
-          debts: [
-            ...state.debts,
-            { ...data, id: generateId() },
-          ],
-        })),
+  load: async () => {
+    set({ loading: true, error: null })
+    try {
+      const res = await fetch('/api/debts')
+      const { debts } = await res.json() as { debts: Debt[] }
+      set({ debts, loading: false })
+    } catch (e) {
+      set({ error: String(e), loading: false })
+    }
+  },
 
-      updateDebt: (id, data) =>
-        set((state) => ({
-          debts: state.debts.map((d) =>
-            d.id === id ? { ...d, ...data } : d
-          ),
-        })),
+  addDebt: async (data) => {
+    const res = await fetch('/api/debts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...data, id: generateId() }),
+    })
+    const { debt } = await res.json() as { debt: Debt }
+    set((s) => ({ debts: [...s.debts, debt] }))
+  },
 
-      removeDebt: (id) =>
-        set((state) => ({
-          debts: state.debts.filter((d) => d.id !== id),
-        })),
-    }),
-    { name: 'debt-planner' }
-  )
-)
+  updateDebt: async (id, data) => {
+    const res = await fetch(`/api/debts/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const { debt } = await res.json() as { debt: Debt }
+    set((s) => ({ debts: s.debts.map((d) => (d.id === id ? debt : d)) }))
+  },
+
+  removeDebt: async (id) => {
+    await fetch(`/api/debts/${id}`, { method: 'DELETE' })
+    set((s) => ({ debts: s.debts.filter((d) => d.id !== id) }))
+  },
+}))

--- a/src/store/usePaymentStore.ts
+++ b/src/store/usePaymentStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
 import type { Payment, PaymentType } from '../types/payment'
 
 const generateId = () =>
@@ -7,29 +6,41 @@ const generateId = () =>
 
 interface PaymentStore {
   payments: Payment[]
-  addPayment: (debtId: string, date: string, amount: number, type: PaymentType, note?: string) => void
-  removePayment: (id: string) => void
+  loading: boolean
+  error: string | null
+  load: () => Promise<void>
+  addPayment: (debtId: string, date: string, amount: number, type: PaymentType, note?: string) => Promise<void>
+  removePayment: (id: string) => Promise<void>
 }
 
+export const usePaymentStore = create<PaymentStore>()((set) => ({
+  payments: [],
+  loading: false,
+  error: null,
 
-export const usePaymentStore = create<PaymentStore>()(
-  persist(
-    (set) => ({
-      payments: [],
+  load: async () => {
+    set({ loading: true, error: null })
+    try {
+      const res = await fetch('/api/payments')
+      const { payments } = await res.json() as { payments: Payment[] }
+      set({ payments, loading: false })
+    } catch (e) {
+      set({ error: String(e), loading: false })
+    }
+  },
 
-      addPayment: (debtId, date, amount, type, note) =>
-        set((state) => ({
-          payments: [
-            ...state.payments,
-            { id: generateId(), debtId, date, amount, type, note },
-          ],
-        })),
+  addPayment: async (debtId, date, amount, type, note) => {
+    const res = await fetch('/api/payments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: generateId(), debtId, date, amount, type, note }),
+    })
+    const { payment } = await res.json() as { payment: Payment }
+    set((s) => ({ payments: [...s.payments, payment] }))
+  },
 
-      removePayment: (id) =>
-        set((state) => ({
-          payments: state.payments.filter((p) => p.id !== id),
-        })),
-    }),
-    { name: 'debt-planner-payments' }
-  )
-)
+  removePayment: async (id) => {
+    await fetch(`/api/payments/${id}`, { method: 'DELETE' })
+    set((s) => ({ payments: s.payments.filter((p) => p.id !== id) }))
+  },
+}))

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["server/**/*", "src/types/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
     host: '0.0.0.0', // required for Docker to expose the dev server
     port: 5173,
     allowedHosts: true, // allow any hostname (covers Docker, reverse proxies, custom hostnames)
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
   },
 })


### PR DESCRIPTION
## Summary

- Adds a lightweight **Hono** API server with **better-sqlite3** (SQLite) replacing the previous Zustand `persist`/localStorage setup
- Single Node process serves both `/api/*` endpoints and the built Vite frontend on port 3000
- Docker Compose prod profile mounts a named volume (`db-data`) at `/app/data` so the database file survives container rebuilds and image updates

## New files

| File | Purpose |
|------|---------|
| `server/db.ts` | SQLite init, WAL mode, schema (`debts` + `payments` tables) |
| `server/routes/debts.ts` | GET / POST / PUT / DELETE `/api/debts` |
| `server/routes/payments.ts` | GET / POST / DELETE `/api/payments` |
| `server/index.ts` | Hono app, static file serving, `/api/migrate` endpoint |
| `src/components/MigrationBanner.tsx` | One-click migration from old localStorage data |
| `tsconfig.server.json` | TypeScript config for the server |

## Migration path

On first load, if the browser still holds the old Zustand localStorage keys (`debt-planner`, `debt-planner-payments`), a yellow banner appears with a **Migrate now** button. This POSTs all existing debts and payments to `/api/migrate`, then clears localStorage. The endpoint uses `INSERT OR IGNORE` so it is safe to run more than once.

## Dev workflow

```bash
npm run dev:server   # API server with tsx watch (port 3000)
npm run dev          # Vite dev server with /api proxy (port 5173)
```

## Deploy

```bash
docker compose --profile prod up -d --build
```

## Test plan

- [ ] `npm run dev:server` starts without errors; `curl localhost:3000/api/debts` returns `{"debts":[]}`
- [ ] Add a debt via the UI — appears after reload
- [ ] Log a payment — persists after reload
- [ ] With old localStorage data present, migration banner appears and migrating moves data correctly
- [ ] `docker compose --profile prod up -d --build` builds and starts on port 3000
- [ ] Rebuild container (`--build`) with existing `db-data` volume — data is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)